### PR TITLE
Agressively-replace image attributes

### DIFF
--- a/src/streamlit_image_coordinates/__init__.py
+++ b/src/streamlit_image_coordinates/__init__.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import base64
-import hashlib
 from io import BytesIO
 from pathlib import Path
 
@@ -50,15 +49,11 @@ def streamlit_image_coordinates(
     else:
         raise ValueError("Must pass a string, Path, or object with a save method")
 
-    _str_repr = f"streamlit_image_coordinates({src}, {height}, {width}, {key})"
-
-    _key = hashlib.md5(_str_repr.encode("utf-8")).hexdigest()
-
     component_value = _component_func(
         src=src,
         height=height,
         width=width,
-        key=_key,
+        key=key,
     )
 
     return component_value

--- a/src/streamlit_image_coordinates/frontend/main.js
+++ b/src/streamlit_image_coordinates/frontend/main.js
@@ -12,17 +12,21 @@ function sendValue(value) {
  * the component is initially loaded, and then again every time the
  * component gets new data from Python.
  */
-function onRender(event) {
-  // Only run the render code the first time the component is loaded.
-  if (!window.rendered) {
-    // You most likely want to get the data passed in like this
-    let {src, height, width} = event.detail.args
 
-    const img = document.getElementById("image")
+function clickListener(event) {
+  const {offsetX, offsetY} = event
+  sendValue({x: offsetX, y: offsetY})
+}
+
+function onRender(event) {
+  let {src, height, width} = event.detail.args
+
+  const img = document.getElementById("image")
+
+  if (img.src !== src || (height && img.height !== height) || (width && img.width !== width)) {
     img.src = src
 
     img.onload = () => {
-
       if (!width && !height) {
         width = img.naturalWidth
         height = img.naturalHeight
@@ -40,15 +44,9 @@ function onRender(event) {
       Streamlit.setFrameHeight(height)
 
       // When image is clicked, send the coordinates to Python through sendValue
-
-      img.addEventListener("click", (e) => {
-        const {offsetX, offsetY} = e
-        sendValue({x: offsetX, y: offsetY})
-      })
-
-      // You'll most likely want to pass some data back to Python like this
-      // sendValue({output1: "foo", output2: "bar"})
-      window.rendered = true
+      if (!img.onclick) {
+        img.onclick = clickListener
+      }
     }
   }
 }
@@ -57,5 +55,3 @@ function onRender(event) {
 Streamlit.events.addEventListener(Streamlit.RENDER_EVENT, onRender)
 // Tell Streamlit that the component is ready to receive events
 Streamlit.setComponentReady()
-// Render with the correct height, if this is a fixed-height component
-// Streamlit.setFrameHeight(100)


### PR DESCRIPTION
Change the key of the image to simply be the passed-in key (rather than the hash of the passed-in attributes), so that changing the image source doesn't redraw the image component, but simply changes the src attribute.

This has the primary benefit of significantly improving the redraw-the-image-after-click use-case.