### PR TITLE
Add use_column_width option

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.4
+    hooks:
+      - id: ruff
+        args:
+          - --fix
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: "v1.9.0"
+    hooks:
+      - id: mypy
+        args:
+          - --ignore-missing-imports
+          - --follow-imports=silent
+        additional_dependencies:
+          - types-all
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0 # Use the ref you want to point at
+    hooks:
+      - id: trailing-whitespace

--- a/pages/dynamic_update.py
+++ b/pages/dynamic_update.py
@@ -1,6 +1,5 @@
 import streamlit as st
 from PIL import Image, ImageDraw
-
 from streamlit_image_coordinates import streamlit_image_coordinates
 
 st.set_page_config(
@@ -29,20 +28,19 @@ def get_ellipse_coords(point: tuple[int, int]) -> tuple[int, int, int, int]:
     )
 
 
-with st.echo("below"):
-    with Image.open("kitty.jpeg") as img:
-        draw = ImageDraw.Draw(img)
+with st.echo("below"), Image.open("kitty.jpeg") as img:
+    draw = ImageDraw.Draw(img)
 
-        # Draw an ellipse at each coordinate in points
-        for point in st.session_state["points"]:
-            coords = get_ellipse_coords(point)
-            draw.ellipse(coords, fill="red")
+    # Draw an ellipse at each coordinate in points
+    for point in st.session_state["points"]:
+        coords = get_ellipse_coords(point)
+        draw.ellipse(coords, fill="red")
 
-        value = streamlit_image_coordinates(img, key="pil")
+    value = streamlit_image_coordinates(img, key="pil")
 
-        if value is not None:
-            point = value["x"], value["y"]
+    if value is not None:
+        point = value["x"], value["y"]
 
-            if point not in st.session_state["points"]:
-                st.session_state["points"].append(point)
-                st.experimental_rerun()
+        if point not in st.session_state["points"]:
+            st.session_state["points"].append(point)
+            st.experimental_rerun()

--- a/pages/more_formats.py
+++ b/pages/more_formats.py
@@ -1,7 +1,6 @@
 import numpy as np
 import streamlit as st
 from PIL import Image
-
 from streamlit_image_coordinates import streamlit_image_coordinates
 
 st.set_page_config(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,9 @@
 [tool.ruff]
 exclude = [".git", ".vscode", ".pytest_cache", ".mypy_cache", ".env"]
-ignore = ["B008", "ISC001", "E501", "W191"]
 line-length = 88
+
+[tool.ruff.lint]
+ignore = ["B008", "ISC001", "E501", "W191"]
 select = [
     "B",
     "E",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,31 @@
+[tool.ruff]
+exclude = [".git", ".vscode", ".pytest_cache", ".mypy_cache", ".env"]
+ignore = ["B008", "ISC001", "E501", "W191"]
+line-length = 88
+select = [
+    "B",
+    "E",
+    "F",
+    "W",
+    "I",
+    "N",
+    "C4",
+    "EXE",
+    "ISC",
+    "ICN",
+    "PIE",
+    "PT",
+    "RET",
+    "SIM",
+    "ERA",
+    "PLC",
+    "RUF",
+    "ARG",
+]
+
+[tool.mypy]
+files = ["**/*.py"]
+follow_imports = "silent"
+ignore_missing_imports = true
+scripts_are_modules = true
+python_version = "3.9"

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setuptools.setup(
     name="streamlit-image-coordinates",
-    version="0.1.6",
+    version="0.1.7",
     author="Zachary Blackwood",
     author_email="zachary@streamlit.io",
     description=(

--- a/src/streamlit_image_coordinates/__init__.py
+++ b/src/streamlit_image_coordinates/__init__.py
@@ -8,6 +8,7 @@ import numpy as np
 import streamlit as st
 import streamlit.components.v1 as components
 from PIL import Image
+from streamlit.elements.image import UseColumnWith
 
 # Tell streamlit that there is a component called streamlit_image_coordinates,
 # and that the code to display that component is in the "frontend" folder
@@ -23,6 +24,7 @@ def streamlit_image_coordinates(
     height: int | None = None,
     width: int | None = None,
     key: str | None = None,
+    use_column_width: UseColumnWith | str | None = None,
 ):
     """
     Take an image source and return the coordinates of the image clicked
@@ -35,6 +37,12 @@ def streamlit_image_coordinates(
         The height of the image. If None, the height will be the original height
     width : int | None
         The width of the image. If None, the width will be the original width
+    use_column_width : "auto", "always", "never", or bool
+            If "auto", set the image's width to its natural size,
+            but do not exceed the width of the column.
+            If "always" or True, set the image's width to the column width.
+            If "never" or False, set the image's width to its natural size.
+            Note: if set, `use_column_width` takes precedence over the `width` parameter.
     """
 
     if isinstance(source, Path) or isinstance(source, str):
@@ -63,6 +71,7 @@ def streamlit_image_coordinates(
         src=src,
         height=height,
         width=width,
+        use_column_width=use_column_width,
         key=key,
     )
 

--- a/src/streamlit_image_coordinates/__init__.py
+++ b/src/streamlit_image_coordinates/__init__.py
@@ -45,7 +45,7 @@ def streamlit_image_coordinates(
             Note: if set, `use_column_width` takes precedence over the `width` parameter.
     """
 
-    if isinstance(source, Path) or isinstance(source, str):
+    if isinstance(source, (Path, str)):
         if not str(source).startswith("http"):
             content = Path(source).read_bytes()
             src = "data:image/png;base64," + base64.b64encode(content).decode("utf-8")
@@ -67,15 +67,13 @@ def streamlit_image_coordinates(
             "Must pass a string, Path, numpy array or object with a save method"
         )
 
-    component_value = _component_func(
+    return _component_func(
         src=src,
         height=height,
         width=width,
         use_column_width=use_column_width,
         key=key,
     )
-
-    return component_value
 
 
 def main():

--- a/src/streamlit_image_coordinates/frontend/main.js
+++ b/src/streamlit_image_coordinates/frontend/main.js
@@ -47,11 +47,11 @@ function onRender(event) {
       } else if (!width) {
         width = height * img.naturalWidth / img.naturalHeight;
       }
-  
+
       img.width = width;
       img.height = height;
     }
-  
+
     Streamlit.setFrameHeight(img.height + 10);
   }
 

--- a/src/streamlit_image_coordinates/frontend/main.js
+++ b/src/streamlit_image_coordinates/frontend/main.js
@@ -14,40 +14,53 @@ function sendValue(value) {
  */
 
 function clickListener(event) {
-  const {offsetX, offsetY} = event
-  sendValue({x: offsetX, y: offsetY})
+  const {offsetX, offsetY} = event;
+  const img = document.getElementById("image");
+
+  sendValue({x: offsetX, y: offsetY, width: img.width, height: img.height});
 }
 
 function onRender(event) {
-  let {src, height, width} = event.detail.args
+  let {src, height, width, use_column_width} = event.detail.args;
 
-  const img = document.getElementById("image")
+  const img = document.getElementById("image");
 
-  if (img.src !== src || (height && img.height !== height) || (width && img.width !== width)) {
-    img.src = src
+  if (img.src !== src) {
+    img.src = src;
+  }
 
-    img.onload = () => {
+  function resizeImage() {
+    img.classList.remove("auto", "fullWidth");
+    img.removeAttribute("width");
+    img.removeAttribute("height");
+
+    if (use_column_width === "always" || use_column_width === true) {
+      img.classList.add("fullWidth");
+    } else if (use_column_width === "auto") {
+      img.classList.add("auto");
+    } else {
       if (!width && !height) {
-        width = img.naturalWidth
-        height = img.naturalHeight
+        width = img.naturalWidth;
+        height = img.naturalHeight;
+      } else if (!height) {
+        height = width * img.naturalHeight / img.naturalWidth;
+      } else if (!width) {
+        width = height * img.naturalWidth / img.naturalHeight;
       }
-      else if (!height) {
-        height = width * img.naturalHeight / img.naturalWidth
-      }
-      else if (!width) {
-        width = height * img.naturalWidth / img.naturalHeight
-      }
-
-      img.width = width
-      img.height = height
-
-      Streamlit.setFrameHeight(height + 10)
-
-      // When image is clicked, send the coordinates to Python through sendValue
-      if (!img.onclick) {
-        img.onclick = clickListener
-      }
+  
+      img.width = width;
+      img.height = height;
     }
+  
+    Streamlit.setFrameHeight(img.height + 10);
+  }
+
+  img.onload = resizeImage;
+  window.addEventListener("resize", resizeImage);
+
+  // When image is clicked, send the coordinates to Python through sendValue
+  if (!img.onclick) {
+    img.onclick = clickListener;
   }
 }
 

--- a/src/streamlit_image_coordinates/frontend/style.css
+++ b/src/streamlit_image_coordinates/frontend/style.css
@@ -1,0 +1,9 @@
+.auto {
+    width: auto;
+    height: auto;
+}
+
+.fullWidth {
+    width: 100%;
+    height: auto;
+}

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,6 +1,5 @@
 import streamlit as st
 from PIL import Image
-
 from streamlit_image_coordinates import streamlit_image_coordinates
 
 st.set_page_config(

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -61,3 +61,14 @@ with col4:
         )
 
         st.write(value)
+
+st.write("## Full width example")
+
+with st.echo("below"):
+    value = streamlit_image_coordinates(
+        "kitty.jpeg",
+        key="local4",
+        use_column_width="always",
+    )
+
+    st.write(value)


### PR DESCRIPTION
Had the same need as in https://github.com/blackary/streamlit-image-coordinates/issues/3, so I gave implementing it a shot.

Should be backwards-compatible, though the returned value now has extra `width` and `height` attributes so that if the column width is being used you can figure out where the click was on the resized image.

Happy to make changes if I've done something wrong!